### PR TITLE
ImageToken - Cacheable Until

### DIFF
--- a/src/image/token/image-token.ts
+++ b/src/image/token/image-token.ts
@@ -36,6 +36,14 @@ export class ImageToken extends Token {
     this.addVerbs(ImageToken.VERB);
   }
 
+  cacheableUntil(expiration: number): ImageToken {
+    this.setExpiration(expiration);
+    this.setIssuedAt(null);
+    this.setTokenId(String(expiration));
+
+    return this;
+  }
+
   toClaims(): ImageTokenClaims {
     if (typeof this.policy !== 'undefined') {
       this.setObjects(this.policy.toClaims().obj);

--- a/src/platform/authentication/token.ts
+++ b/src/platform/authentication/token.ts
@@ -36,7 +36,7 @@ export class Token {
    * @description the issuing time of the token in UNIX time
    * @type {number}
    */
-  public issuedAt: number = Math.floor(new Date().getTime() / 1000) - 10;
+  public issuedAt: number | null = Math.floor(new Date().getTime() / 1000) - 10;
 
   /**
    * @description the token expiration in UNIX time
@@ -48,7 +48,7 @@ export class Token {
    * @description a unique token id, can be used as nonce
    * @type {string}
    */
-  public tokenId: string = crypto.randomBytes(6).toString('hex');
+  public tokenId: string | null = crypto.randomBytes(6).toString('hex');
 
   /**
    * @description additional ad-hoc claims that are added to the token
@@ -64,6 +64,26 @@ export class Token {
    */
   setIssuer(ns: string, identifier: string): this {
     this.issuer = ns + identifier;
+    return this;
+  }
+
+  /**
+   * @description sets the issued at of the token
+   * @param {number} issuedAt
+   * @returns {Token}
+   */
+  setIssuedAt(issuedAt: number | null): this {
+    this.issuedAt = issuedAt;
+    return this;
+  }
+
+  /**
+   * @description sets the token id
+   * @param {string} tokenId
+   * @returns {Token}
+   */
+  setTokenId(tokenId: string | null): this {
+    this.tokenId = tokenId;
     return this;
   }
 

--- a/test/server/image/token/image-token.spec.ts
+++ b/test/server/image/token/image-token.spec.ts
@@ -57,4 +57,20 @@ describe('image token', () => {
     expect(claims.aud).to.contain('urn:service:image.operations');
     expect(claims.obj).to.equal(null);
   });
+
+  it('toClaims should properly return claims set for caching', () => {
+    const policy = new Policy({
+      maxHeight: 1000,
+      maxWidth: 1500,
+      path: '/path/to/image.jpg',
+    });
+
+    const token = new ImageToken({ policy }).cacheableUntil(1000);
+
+    const claims = token.toClaims();
+    expect(claims.aud).to.contain('urn:service:image.operations');
+    expect(claims.iat).to.equal(null);
+    expect(claims.jti).to.equal(String(1000));
+    expect(claims.exp).to.equal(1000);
+  });
 });


### PR DESCRIPTION
Add cacheableUntil method to ImageToken, this method configures the token to be reproducible so that it does not invalidates the CDN cache when placed in the URL