### PR TITLE
Nissix plugin scope-packages on media-platform-js-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "mime-types": "^2.1.27",
     "mocha": "^7.1.1",
     "nock": "^12.0.3",
-    "okidoc": "^2.0.0",
+    "@wix/okidoc": "^2.0.0",
     "prettier": "^2.0.2",
     "prismjs": "^1.19.0",
     "pug": "latest",
@@ -140,7 +140,7 @@
     "typescript": "^3.8.3",
     "uuid": "^7.0.2",
     "wnpm-ci": "^8.0.116",
-    "yoshi": "^4.52.2"
+    "@wix/yoshi": "^4.52.2"
   },
   "prettier": {
     "singleQuote": true,


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 8.222s
error An unexpected error occurred: "https://registry.npmjs.org/@wix%2fokidoc: Not found".
(node:11822) UnhandledPromiseRejectionWarning: Error: Command failed with exit code 1: yarn
    at makeError (/app/node_modules/execa/lib/error.js:59:11)
    at handlePromise (/app/node_modules/execa/index.js:114:26)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:11822) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:11822) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.



Output Log:
Migrating package "media-platform-js-sdk" in .


## Migration from non scope to @wix/scoped packages
> /tmp/21194443d5e45bb11fbca784bea0a0f2

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```
yarn install v1.22.5
[1/5] Validating package.json...
[2/5] Resolving packages...
info If you think this is a bug, please open a bug report with the information provided in "/tmp/21194443d5e45bb11fbca784bea0a0f2/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

