### PR TITLE
Remove content length limit for http-client

### DIFF
--- a/src/platform/http/http-client.spec.ts
+++ b/src/platform/http/http-client.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { createReadStream } from 'fs';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
 
@@ -69,6 +70,22 @@ describe('HTTP client', () => {
         expect(response).to.deep.equal({
           response: 'ok-post-11',
         });
+        done();
+      });
+  });
+
+  it('should send post request with big body', (done) => {
+    const uri = '/_api/test-big-body';
+    apiServer
+      .get(uri)
+      .reply(200, () => createReadStream('/dev/urandom', { end: 50 * 1000 * 1000}));
+
+    httpClient
+      .get(
+        `${domain}${uri}`)
+      .then((response: any) => {
+        // random input is parsed as JSON, thus, becomes smaller
+        expect(response.length).to.gt(40 * 1000 * 1000);
         done();
       });
   });

--- a/src/platform/http/http-client.ts
+++ b/src/platform/http/http-client.ts
@@ -17,6 +17,8 @@ interface HTTPRequest {
   headers: AuthorizationHeader;
   data?: any;
   params?: object;
+  maxContentLength: number;
+  maxBodyLenth: number;
 }
 
 export interface HTTPRequestParams {
@@ -72,6 +74,8 @@ export class HTTPClient implements IHTTPClient {
       method: httpMethod,
       url,
       headers: header,
+      maxContentLength: Infinity,
+      maxBodyLenth: Infinity,
     };
 
     switch (httpMethod) {
@@ -108,11 +112,13 @@ export class HTTPClient implements IHTTPClient {
   ): Promise<T> {
     const header = this.authenticator.getHeader(token);
 
-    const options = {
+    const options: HTTPRequest = {
       method: 'POST' as HttpMethod,
       url,
       data: form,
       headers: header,
+      maxContentLength: Infinity,
+      maxBodyLenth: Infinity,
     };
 
     return axios(options)


### PR DESCRIPTION
We are using this to upload tarballs 10++ MB in size, so, need to remove this content length cap